### PR TITLE
fix: grant commitizen Action commit permission

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-
+permissions:
+  contents: write
 jobs:
   bump_version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Attempt to fix failing commitizen Action by granting `content: write` permission.

- https://github.com/hkeeler/cc-lab/actions/runs/8956543356/job/24598462562